### PR TITLE
fix: уточнить подключения в webhook и включить strict types

### DIFF
--- a/bracelet/webhook.php
+++ b/bracelet/webhook.php
@@ -1,6 +1,11 @@
 <?php
-require 'config.php';
-require 'calc.php';
+declare(strict_types=1);
+
+// Подключаем файл конфигурации приложения
+require __DIR__ . '/config.php';
+
+// Подключаем функции расчёта параметров браслета
+require __DIR__ . '/calc.php';
 
 // Получаем заголовки и IP-адрес отправителя
 $headers  = function_exists('getallheaders') ? getallheaders() : [];


### PR DESCRIPTION
## Summary
- use absolute paths in webhook requires
- enable strict types in webhook

## Testing
- `composer install --no-progress`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688cfa2dd88c8333b7b94e193104293d