### PR TITLE
Добавлена проверка DB_NAME в конфигурации

### DIFF
--- a/bracelet/config.php
+++ b/bracelet/config.php
@@ -30,8 +30,16 @@ define('HOST', $_ENV['HOST'] ?? getenv('HOST') ?: '');
  * Имя базы данных Postgres.
  *
  * @var string
+ *
+ * @throws RuntimeException Если переменная окружения не задана.
  */
-define('DB_NAME', $_ENV['DB_NAME'] ?? getenv('DB_NAME') ?: '');
+$dbName = $_ENV['DB_NAME'] ?? getenv('DB_NAME');
+if ($dbName === false || $dbName === null || $dbName === '') {
+    // Без имени базы данных невозможно установить соединение
+    logError('Отсутствует переменная окружения DB_NAME');
+    throw new RuntimeException('Переменная окружения DB_NAME не задана');
+}
+define('DB_NAME', $dbName);
 
 /**
  * Пользователь базы данных.


### PR DESCRIPTION
## Summary
- Добавлена проверка на наличие переменной окружения DB_NAME
- При отсутствии DB_NAME логируется ошибка и выбрасывается RuntimeException

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689c3d08e7f8833399e5e20a902a7bd4