### PR TITLE
Рефакторинг webhook для браслета

### DIFF
--- a/bracelet/RequestHandler.php
+++ b/bracelet/RequestHandler.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/logger.php';
+require_once __DIR__ . '/network.php';
+require_once __DIR__ . '/telegram_ip.php';
+
+/**
+ * Класс, отвечающий за чтение и валидацию входящего запроса от Telegram.
+ *
+ * Выполняет проверку IP-адреса отправителя, секретного токена,
+ * размера тела запроса и корректность JSON.
+ */
+class RequestHandler
+{
+    /**
+     * Флаг доверия к заголовку `X-Forwarded-For`.
+     * Если `true`, IP-адрес может быть взят из этого заголовка.
+     */
+    private bool $trustForwarded;
+
+    /**
+     * Максимально допустимый размер тела запроса в байтах.
+     */
+    private int $maxBodySize;
+
+    /**
+     * @param bool $trustForwarded Доверять ли заголовку `X-Forwarded-For`.
+     * @param int  $maxBodySize    Максимально допустимый размер тела запроса в байтах.
+     */
+    public function __construct(bool $trustForwarded = false, int $maxBodySize = 1048576)
+    {
+        $this->trustForwarded = $trustForwarded;
+        $this->maxBodySize = $maxBodySize; // 1 МБ по умолчанию
+    }
+
+    /**
+     * Считывает и валидирует запрос, возвращая данные сообщения.
+     *
+     * @return array{message: array, chatId: int, userId: int, userLang: string} Данные сообщения пользователя.
+     */
+    public function handle(): array
+    {
+        // Получаем заголовки и приводим их к нижнему регистру для единообразия.
+        $headers = function_exists('getallheaders') ? getallheaders() : [];
+        $headers = array_change_key_case($headers, CASE_LOWER);
+
+        // Определяем IP-адрес отправителя с учётом возможного прокси.
+        $remoteIp = resolveRemoteIp($headers, $_SERVER, $this->trustForwarded);
+
+        // Разрешаем запросы только от Telegram.
+        if (!isTelegramIP($remoteIp)) {
+            logError('Недопустимый запрос: IP ' . $remoteIp);
+            http_response_code(403);
+            exit;
+        }
+
+        // Проверяем секретный токен, если он задан.
+        $secret = $_ENV['WEBHOOK_SECRET'] ?? getenv('WEBHOOK_SECRET') ?: '';
+        if ($secret !== '') {
+            if (!isset($headers['x-telegram-bot-api-secret-token']) ||
+                !hash_equals($secret, $headers['x-telegram-bot-api-secret-token'])) {
+                $token = $headers['x-telegram-bot-api-secret-token'] ?? '';
+                $maskedToken = $token !== '' ? substr($token, 0, 4) . '***' : '';
+                logError('Недопустимый токен: ' . $maskedToken . ', IP ' . $remoteIp);
+                http_response_code(403);
+                exit;
+            }
+        }
+
+        // Проверяем указанный клиентом размер тела.
+        $contentLengthHeader = (int)($headers['content-length'] ?? ($_SERVER['CONTENT_LENGTH'] ?? 0));
+        if ($contentLengthHeader > $this->maxBodySize) {
+            logError('Превышен допустимый размер запроса по заголовку: ' . $contentLengthHeader . ' байт');
+            http_response_code(413);
+            exit;
+        }
+
+        // Считываем тело запроса из входного потока.
+        $body = file_get_contents('php://input');
+        // Фиксируем тело запроса и IP отправителя для отладки.
+        logInfo('Получено тело запроса от IP ' . $remoteIp . ': ' . $body);
+
+        // Проверяем реальный размер полученных данных.
+        if (strlen($body) > $this->maxBodySize) {
+            logError('Превышен допустимый размер запроса: ' . strlen($body) . ' байт');
+            http_response_code(413);
+            exit;
+        }
+
+        // Тело не должно быть пустым.
+        if (trim($body) === '') {
+            $errorMessage = 'Пустое тело запроса';
+            logError($errorMessage . ', IP ' . $remoteIp);
+            http_response_code(400);
+            echo $errorMessage;
+            exit;
+        }
+
+        // Пытаемся декодировать JSON.
+        $update = json_decode($body, true);
+        if ($update === null && json_last_error() !== JSON_ERROR_NONE) {
+            $errorMessage = 'Некорректный JSON: ' . json_last_error_msg();
+            logError($errorMessage . '; данные: ' . $body . '; IP ' . $remoteIp);
+            http_response_code(400);
+            echo $errorMessage;
+            exit;
+        }
+
+        // Убедимся, что в обновлении есть ключ `message`.
+        if (!isset($update['message'])) {
+            logError(
+                'Некорректное обновление: поле message отсутствует. Полный JSON: '
+                . json_encode($update, JSON_UNESCAPED_UNICODE)
+            );
+            exit;
+        }
+
+        $msg = $update['message'];
+        $decodedMsg = json_encode($msg, JSON_UNESCAPED_UNICODE);
+        logInfo('Получено сообщение: ' . $decodedMsg . '; IP ' . $remoteIp);
+
+        $chatId = $msg['chat']['id'];
+        $userId = $msg['from']['id'];
+        $userLang = $msg['from']['language_code'] ?? 'ru';
+
+        return [
+            'message' => $msg,
+            'chatId' => $chatId,
+            'userId' => $userId,
+            'userLang' => $userLang,
+        ];
+    }
+}

--- a/bracelet/StateStorage.php
+++ b/bracelet/StateStorage.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Класс для работы с таблицами `user_state` и `log` базы данных.
+ *
+ * Обеспечивает чтение, сохранение и очистку состояния пользователя,
+ * а также фиксацию результатов диалога в журнале.
+ */
+class StateStorage
+{
+    /** @var PDO Подключение к базе данных. */
+    private PDO $pdo;
+
+    /**
+     * @param PDO $pdo Готовое подключение к базе данных.
+     */
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Инициализирует состояние пользователя для начала сценария.
+     * Удаляет предыдущие данные и вставляет новую запись на первом шаге.
+     *
+     * @param int $userId Идентификатор пользователя Telegram.
+     *
+     * @return void
+     */
+    public function initState(int $userId): void
+    {
+        $this->pdo->prepare('DELETE FROM user_state WHERE tg_user_id = ?')->execute([$userId]);
+        $this->pdo->prepare('INSERT INTO user_state (tg_user_id, step, data) VALUES (?,1,?::jsonb)')
+            ->execute([$userId, json_encode([], JSON_UNESCAPED_UNICODE)]);
+    }
+
+    /**
+     * Возвращает текущее состояние пользователя.
+     *
+     * @param int $userId Идентификатор пользователя Telegram.
+     *
+     * @return array{step:int,data:array}|null Массив состояния или `null`, если диалог не начат.
+     */
+    public function getState(int $userId): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT step, data FROM user_state WHERE tg_user_id = ?');
+        $stmt->execute([$userId]);
+        /** @var array{step:int,data:string}|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null; // Состояние отсутствует
+        }
+        return [
+            'step' => (int)$row['step'],
+            'data' => json_decode($row['data'], true) ?: [],
+        ];
+    }
+
+    /**
+     * Сохраняет текущий шаг диалога и данные пользователя.
+     *
+     * @param int   $userId Идентификатор пользователя Telegram.
+     * @param int   $step   Номер следующего шага.
+     * @param array $data   Накопленные данные пользователя.
+     *
+     * @return void
+     */
+    public function saveState(int $userId, int $step, array $data): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE user_state SET step = ?, data = ?, updated_at = CURRENT_TIMESTAMP WHERE tg_user_id = ?');
+        $stmt->execute([$step, json_encode($data, JSON_UNESCAPED_UNICODE), $userId]);
+    }
+
+    /**
+     * Сохраняет итоговый результат расчёта и очищает состояние пользователя.
+     *
+     * @param int    $userId      Идентификатор пользователя Telegram.
+     * @param array  $data        Данные, собранные в ходе диалога.
+     * @param string $resultText  Текст результата для записи в лог.
+     *
+     * @return void
+     */
+    public function saveResult(int $userId, array $data, string $resultText): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO log (tg_user_id,wrist_cm,wraps,pattern,magnet_mm,tolerance_mm,result_text) VALUES (?,?,?,?,?,?,?)');
+        $stmt->execute([
+            $userId,
+            $data['wrist_cm'],
+            $data['wraps'],
+            $data['pattern'],
+            $data['magnet_mm'],
+            $data['tolerance_mm'],
+            $resultText,
+        ]);
+        $this->clearState($userId); // После сохранения результата состояние больше не нужно
+    }
+
+    /**
+     * Удаляет состояние пользователя без сохранения результата.
+     *
+     * @param int $userId Идентификатор пользователя Telegram.
+     *
+     * @return void
+     */
+    public function clearState(int $userId): void
+    {
+        $this->pdo->prepare('DELETE FROM user_state WHERE tg_user_id = ?')->execute([$userId]);
+    }
+}

--- a/bracelet/TelegramApi.php
+++ b/bracelet/TelegramApi.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/logger.php';
+
+/**
+ * Класс-обёртка для работы с API Telegram.
+ *
+ * Содержит метод отправки сообщений с базовой обработкой ошибок
+ * уровня cURL и HTTP.
+ */
+class TelegramApi
+{
+    /**
+     * Отправляет сообщение пользователю.
+     *
+     * @param string     $text  Текст сообщения.
+     * @param int|string $chat  ID чата или @username получателя.
+     * @param array      $extra Дополнительные параметры API.
+     *
+     * @return bool true при успешной отправке.
+     */
+    public function send(string $text, int|string $chat, array $extra = []): bool
+    {
+        $url  = API_URL . 'sendMessage';
+        $data = array_merge(['chat_id' => $chat, 'text' => $text], $extra);
+
+        // Инициализируем cURL для отправки POST-запроса.
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_POST           => true,                     // Используем метод POST
+            CURLOPT_POSTFIELDS     => http_build_query($data),  // Тело запроса в формате key=value
+            CURLOPT_RETURNTRANSFER => true,                     // Возвращаем ответ как строку
+            CURLOPT_CONNECTTIMEOUT => 5,                        // Ждём соединение не более 5 секунд
+            CURLOPT_TIMEOUT        => 10,                       // Общее ожидание ответа — до 10 секунд
+        ]);
+
+        $response = curl_exec($ch);
+
+        // Проверяем наличие ошибок на уровне cURL.
+        if ($response === false) {
+            logError('Ошибка cURL: ' . curl_error($ch));
+            curl_close($ch);
+            return false;
+        }
+
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        // Анализируем HTTP-статус ответа.
+        if ($httpCode < 200 || $httpCode >= 300) {
+            logError('Ошибка HTTP: статус ' . $httpCode . '; ответ: ' . $response);
+            return false;
+        }
+
+        // Декодируем JSON-ответ Telegram.
+        $decoded = json_decode($response, true);
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            logError('Некорректный JSON в ответе API: ' . $response);
+            return false;
+        }
+
+        // Проверяем наличие и значение флага `ok`.
+        if (!isset($decoded['ok']) || $decoded['ok'] === false) {
+            $desc = $decoded['description'] ?? 'неизвестная ошибка';
+            logError('Ошибка API Telegram: ' . $desc);
+            return false;
+        }
+
+        return true; // Всё прошло успешно
+    }
+}


### PR DESCRIPTION
## Summary
- вынесена обработка входящего HTTP-запроса в класс `RequestHandler`
- добавлено хранилище `StateStorage` для работы с таблицами `user_state` и `log`
- вынесена отправка сообщений в класс `TelegramApi`, webhook теперь лишь оркестрирует

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a44425b6e88333b6c2b8a57a7edc47