### PR TITLE
Рефакторинг webhook: класс WebhookProcessor

### DIFF
--- a/bracelet/webhook.php
+++ b/bracelet/webhook.php
@@ -15,163 +15,271 @@ namespace Bracelet {
     use Throwable;
 
     /**
-     * Запускает обработку входящего HTTP-запроса Telegram.
+     * Класс, инкапсулирующий работу webhook-скрипта.
      *
-     * Функция выступает "оркестратором": выполняет загрузку конфигурации,
-     * подготовку зависимостей, пошаговый сценарий и отправку ответа
-     * пользователю. Выделение логики в функцию позволяет подключать файл
-     * через автозагрузку без немедленного выполнения.
-     *
-     * @return void
+     * Он выполняет загрузку конфигурации, проверку входного запроса,
+     * взаимодействие с хранилищем состояния и отправку ответа
+     * пользователю Telegram. Основной публичный метод {@see handle()}
+     * является точкой входа и последовательно выполняет все шаги.
      */
-    function runWebhook(): void
+    final class WebhookProcessor
     {
-        try {
-            // Подключаем конфигурацию, где задаются переменные окружения.
-            require __DIR__ . '/config.php';
-        } catch (Throwable $e) {
-            // Фиксируем ошибку конфигурации и пробрасываем исключение,
-            // чтобы тесты могли её перехватить.
-            logError('Ошибка конфигурации: ' . $e->getMessage());
-            throw $e;
-        }
+        /** @var RequestHandler Объект для чтения и валидации запроса */
+        private RequestHandler $requestHandler;
 
-        // Определяем, доверять ли заголовку X-Forwarded-For.
-        $trustForwarded = filter_var(
-            $_ENV['TRUST_FORWARDED'] ?? getenv('TRUST_FORWARDED'),
-            FILTER_VALIDATE_BOOLEAN
-        );
+        /** @var TelegramApi Клиент Telegram API */
+        private TelegramApi $telegram;
 
-        // Создаём необходимые объекты для обработки запроса.
-        $requestHandler = new RequestHandler($trustForwarded);
-        $telegram       = new TelegramApi();
+        /** @var StateStorage Хранилище шагов сценария */
+        private StateStorage $storage;
 
-        // Читаем и валидируем входящий запрос.
-        $req      = $requestHandler->handle();
-        $msg      = $req['message'];
-        $chatId   = $req['chatId'];
-        $userId   = $req['userId'];
-        $userLang = $req['userLang'];
+        /** @var array Входящее сообщение Telegram */
+        private array $msg = [];
 
-        // Устанавливаем соединение с базой данных.
-        try {
-            /** @var PDO $pdo Подключение к базе данных */
-            $pdo = new PDO(DB_DSN, DB_USER, DB_PASSWORD, [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-            ]);
-        } catch (PDOException $e) {
-            $text = $userLang === 'en'
-                ? 'Database connection error. Please try again later.'
-                : 'Ошибка подключения к базе данных. Попробуй позже.';
-            logError('Ошибка подключения к БД: ' . $e->getMessage());
-            if (!$telegram->send($text, $chatId)) {
-                logError('Предупреждение: не удалось отправить уведомление об ошибке подключения, чат ' . $chatId);
+        /** @var int Идентификатор чата */
+        private int $chatId = 0;
+
+        /** @var int Идентификатор пользователя */
+        private int $userId = 0;
+
+        /** @var string Язык пользователя */
+        private string $userLang = 'en';
+
+        /** @var array Текущие накопленные данные диалога */
+        private array $data = [];
+
+        /** @var int Номер текущего шага */
+        private int $step = 0;
+
+        /** @var string Последний ответ пользователю */
+        private string $responseText = '';
+
+        /**
+         * Точка входа обработки webhook-запроса.
+         *
+         * Метод последовательно выполняет загрузку конфигурации,
+         * обработку команды `/start`, получение состояния,
+         * вычисление следующего шага и отправку ответа.
+         *
+         * @return void
+         */
+        public function handle(): void
+        {
+            // Подготавливаем окружение и зависимости.
+            if (!$this->loadConfig()) {
+                return; // Ошибки уже залогированы внутри метода.
             }
-            return;
-        }
 
-        $storage = new StateStorage($pdo);
-
-        // Обрабатываем команду /start.
-        if (isset($msg['text']) && preg_match('/^\/start(?:\s|$)/', $msg['text'])) {
-            try {
-                $storage->initState($userId); // Создаём состояние первого шага.
-            } catch (PDOException $e) {
-                logError('Ошибка при инициализации состояния: ' . $e->getMessage());
-                $text = $userLang === 'en'
-                    ? 'Server error. Try again later.'
-                    : 'Ошибка сервера. Попробуй позже.';
-                if (!$telegram->send($text, $chatId)) {
-                    logError('Предупреждение: не удалось отправить сообщение об ошибке инициализации, чат ' . $chatId);
-                }
+            // Специальная обработка команды /start.
+            if ($this->handleStart()) {
                 return;
             }
-            // Первый шаг диалога — запрашиваем обхват запястья.
-            $text = $userLang === 'en'
-                ? 'Step 1 of 5. Enter wrist circumference in centimeters.'
-                : 'Шаг 1 из 5. Введи обхват запястья в сантиметрах.';
-            // Логируем начало сценария.
-            logInfo('Начало сценария: пользователь ' . $userId . ', язык ' . $userLang . ', чат ' . $chatId);
-            if (!$telegram->send($text, $chatId)) {
-                logError('Предупреждение: не удалось отправить стартовое сообщение, чат ' . $chatId);
+
+            // Считываем состояние пользователя и валидируем сообщение.
+            if (!$this->fetchState()) {
+                return;
             }
-            return;
+
+            // Выполняем текущий шаг сценария и сохраняем изменения.
+            $this->processMessage();
+
+            // Отправляем итоговый ответ пользователю.
+            $this->sendResponse();
         }
 
-        // Получаем текущее состояние пользователя.
-        try {
-            $state = $storage->getState($userId);
-        } catch (PDOException $e) {
-            logError('Ошибка чтения состояния: ' . $e->getMessage());
-            $text = $userLang === 'en'
-                ? 'Server error. Try again later.'
-                : 'Ошибка сервера. Попробуй позже.';
-            if (!$telegram->send($text, $chatId)) {
-                logError('Предупреждение: не удалось отправить сообщение об ошибке чтения состояния, чат ' . $chatId);
+        /**
+         * Загружает конфигурацию и подготавливает необходимые объекты.
+         *
+         * @return bool true в случае успеха, false при ошибке подключения к БД.
+         * @throws Throwable Любые проблемы с конфигурацией пробрасываются выше.
+         */
+        private function loadConfig(): bool
+        {
+            try {
+                // Подключаем конфигурацию, где задаются переменные окружения.
+                require __DIR__ . '/config.php';
+            } catch (Throwable $e) {
+                // Фиксируем ошибку конфигурации и пробрасываем исключение,
+                // чтобы тесты могли её перехватить.
+                logError('Ошибка конфигурации: ' . $e->getMessage());
+                throw $e;
             }
-            return;
+
+            // Определяем, доверять ли заголовку X-Forwarded-For.
+            $trustForwarded = filter_var(
+                $_ENV['TRUST_FORWARDED'] ?? getenv('TRUST_FORWARDED'),
+                FILTER_VALIDATE_BOOLEAN
+            );
+
+            // Создаём необходимые объекты для обработки запроса.
+            $this->requestHandler = new RequestHandler($trustForwarded);
+            $this->telegram       = new TelegramApi();
+
+            // Читаем и валидируем входящий запрос.
+            $req            = $this->requestHandler->handle();
+            $this->msg      = $req['message'];
+            $this->chatId   = $req['chatId'];
+            $this->userId   = $req['userId'];
+            $this->userLang = $req['userLang'];
+
+            // Устанавливаем соединение с базой данных.
+            try {
+                /** @var PDO $pdo Подключение к базе данных */
+                $pdo = new PDO(DB_DSN, DB_USER, DB_PASSWORD, [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                ]);
+            } catch (PDOException $e) {
+                $text = $this->userLang === 'en'
+                    ? 'Database connection error. Please try again later.'
+                    : 'Ошибка подключения к базе данных. Попробуй позже.';
+                logError('Ошибка подключения к БД: ' . $e->getMessage());
+                if (!$this->telegram->send($text, $this->chatId)) {
+                    logError('Предупреждение: не удалось отправить уведомление об ошибке подключения, чат ' . $this->chatId);
+                }
+                return false;
+            }
+
+            $this->storage = new StateStorage($pdo);
+
+            return true;
         }
 
-        if ($state === null) {
-            // Диалог не начат — предлагаем отправить /start.
-            $text = $userLang === 'en'
-                ? 'Send /start to begin.'
-                : 'Отправь /start, чтобы начать.';
-            if (!$telegram->send($text, $chatId)) {
-                logError('Предупреждение: не удалось отправить подсказку о /start, чат ' . $chatId);
-            }
-            return;
-        }
-
-        $data = $state['data'];
-        $step = $state['step'];
-
-        // Обрабатываем только текстовые сообщения.
-        if (!isset($msg['text'])) {
-            $text = $userLang === 'en'
-                ? 'Please send a text value.'
-                : 'Пожалуйста, введи значение текстом.';
-            if (!$telegram->send($text, $chatId)) {
-                logError('Предупреждение: не удалось отправить сообщение о необходимости текстового ввода, чат ' . $chatId);
-            }
-            return;
-        }
-
-        $input = trim($msg['text']);
-
-        // Выполняем текущий шаг сценария.
-        $result = processStep($step, $input, $data, $userLang);
-        $next        = $result['next'];
-        $responseText = $result['text'];
-        $data        = $result['data'];
-
-        if ($next === 0) {
-            if ($data !== [] && $step === 5) {
-                // Пользователь успешно прошёл все шаги — сохраняем результат.
+        /**
+         * Обрабатывает команду /start, если она присутствует.
+         *
+         * @return bool true, если команда была обработана и дальше продолжать не нужно.
+         */
+        private function handleStart(): bool
+        {
+            if (isset($this->msg['text']) && preg_match('/^\/start(?:\s|$)/', $this->msg['text'])) {
                 try {
-                    $storage->saveResult($userId, $data, $responseText);
+                    // Создаём состояние первого шага.
+                    $this->storage->initState($this->userId);
                 } catch (PDOException $e) {
-                    logError('Ошибка при сохранении результата: ' . $e->getMessage());
+                    logError('Ошибка при инициализации состояния: ' . $e->getMessage());
+                    $text = $this->userLang === 'en'
+                        ? 'Server error. Try again later.'
+                        : 'Ошибка сервера. Попробуй позже.';
+                    if (!$this->telegram->send($text, $this->chatId)) {
+                        logError('Предупреждение: не удалось отправить сообщение об ошибке инициализации, чат ' . $this->chatId);
+                    }
+                    return true;
+                }
+
+                // Первый шаг диалога — запрашиваем обхват запястья.
+                $text = $this->userLang === 'en'
+                    ? 'Step 1 of 5. Enter wrist circumference in centimeters.'
+                    : 'Шаг 1 из 5. Введи обхват запястья в сантиметрах.';
+
+                // Логируем начало сценария.
+                logInfo('Начало сценария: пользователь ' . $this->userId . ', язык ' . $this->userLang . ', чат ' . $this->chatId);
+                if (!$this->telegram->send($text, $this->chatId)) {
+                    logError('Предупреждение: не удалось отправить стартовое сообщение, чат ' . $this->chatId);
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
+         * Получает текущее состояние пользователя и проверяет входящее сообщение.
+         *
+         * @return bool true, если состояние получено и сообщение валидно.
+         */
+        private function fetchState(): bool
+        {
+            try {
+                $state = $this->storage->getState($this->userId);
+            } catch (PDOException $e) {
+                logError('Ошибка чтения состояния: ' . $e->getMessage());
+                $text = $this->userLang === 'en'
+                    ? 'Server error. Try again later.'
+                    : 'Ошибка сервера. Попробуй позже.';
+                if (!$this->telegram->send($text, $this->chatId)) {
+                    logError('Предупреждение: не удалось отправить сообщение об ошибке чтения состояния, чат ' . $this->chatId);
+                }
+                return false;
+            }
+
+            if ($state === null) {
+                // Диалог не начат — предлагаем отправить /start.
+                $text = $this->userLang === 'en'
+                    ? 'Send /start to begin.'
+                    : 'Отправь /start, чтобы начать.';
+                if (!$this->telegram->send($text, $this->chatId)) {
+                    logError('Предупреждение: не удалось отправить подсказку о /start, чат ' . $this->chatId);
+                }
+                return false;
+            }
+
+            // Обрабатываем только текстовые сообщения.
+            if (!isset($this->msg['text'])) {
+                $text = $this->userLang === 'en'
+                    ? 'Please send a text value.'
+                    : 'Пожалуйста, введи значение текстом.';
+                if (!$this->telegram->send($text, $this->chatId)) {
+                    logError('Предупреждение: не удалось отправить сообщение о необходимости текстового ввода, чат ' . $this->chatId);
+                }
+                return false;
+            }
+
+            $this->data = $state['data'];
+            $this->step = $state['step'];
+            $this->responseText = '';
+
+            return true;
+        }
+
+        /**
+         * Выполняет один шаг сценария и сохраняет состояние пользователя.
+         *
+         * @return void
+         */
+        private function processMessage(): void
+        {
+            $input  = trim($this->msg['text']);
+            $result = processStep($this->step, $input, $this->data, $this->userLang);
+
+            $next              = $result['next'];
+            $this->responseText = $result['text'];
+            $this->data         = $result['data'];
+
+            if ($next === 0) {
+                if ($this->data !== [] && $this->step === 5) {
+                    // Пользователь успешно прошёл все шаги — сохраняем результат.
+                    try {
+                        $this->storage->saveResult($this->userId, $this->data, $this->responseText);
+                    } catch (PDOException $e) {
+                        logError('Ошибка при сохранении результата: ' . $e->getMessage());
+                    }
+                } else {
+                    // Некорректный шаг — очищаем состояние.
+                    $this->storage->clearState($this->userId);
+                    logError('Неизвестный шаг диалога: ' . $this->step);
                 }
             } else {
-                // Некорректный шаг — очищаем состояние.
-                $storage->clearState($userId);
-                logError('Неизвестный шаг диалога: ' . $step);
+                // Сохраняем состояние и переходим к следующему шагу.
+                $this->storage->saveState($this->userId, $next, $this->data);
             }
-        } else {
-            // Сохраняем состояние и переходим к следующему шагу.
-            $storage->saveState($userId, $next, $data);
         }
 
-        // Отправляем пользователю ответ.
-        if (!$telegram->send($responseText, $chatId)) {
-            logError('Предупреждение: не удалось отправить ответ, чат ' . $chatId);
+        /**
+         * Отправляет пользователю подготовленный ответ.
+         *
+         * @return void
+         */
+        private function sendResponse(): void
+        {
+            if (!$this->telegram->send($this->responseText, $this->chatId)) {
+                logError('Предупреждение: не удалось отправить ответ, чат ' . $this->chatId);
+            }
         }
     }
 
     // Если файл запущен напрямую (например, через CLI), запускаем обработку.
     if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === __FILE__) {
-        runWebhook();
+        (new WebhookProcessor())->handle();
     }
 }
 

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use function Bracelet\runWebhook;
+use Bracelet\WebhookProcessor;
 
 // Путь к автозагрузчику Composer.
 $autoload = __DIR__ . '/vendor/autoload.php';
@@ -13,10 +13,10 @@ if (!file_exists($autoload)) {
 }
 require_once $autoload;
 
-// Подключаем скрипт вебхука, определяющий функцию runWebhook.
+// Подключаем класс обработчика webhook-запроса.
 require __DIR__ . '/bracelet/webhook.php';
 
 /**
- * Запускаем обработку входящего HTTP-запроса Telegram.
+ * Создаём обработчик и запускаем обработку входящего HTTP-запроса Telegram.
  */
-runWebhook();
+(new WebhookProcessor())->handle();

--- a/tests/WebhookTest.php
+++ b/tests/WebhookTest.php
@@ -23,13 +23,19 @@ final class WebhookTest extends TestCase
         return $dir;
     }
     /**
-     * Убедимся, что в webhook используется функция processStep вместо switch.
+     * Проверяем, что webhook реализован классом и использует функцию
+     * processStep вместо switch, а index.php создаёт этот класс.
      */
-    public function testWebhookContainsProcessStepCall(): void
+    public function testWebhookUsesProcessorClass(): void
     {
-        $code = file_get_contents(__DIR__ . '/../bracelet/webhook.php');
-        $this->assertStringContainsString('processStep', $code);
-        $this->assertStringNotContainsString('switch ($step)', $code);
+        $webhookCode = file_get_contents(__DIR__ . '/../bracelet/webhook.php');
+        $this->assertStringContainsString('class WebhookProcessor', $webhookCode);
+        $this->assertStringContainsString('processStep', $webhookCode);
+        $this->assertStringNotContainsString('switch ($step)', $webhookCode);
+        $this->assertStringNotContainsString('function runWebhook', $webhookCode);
+
+        $indexCode = file_get_contents(__DIR__ . '/../index.php');
+        $this->assertStringContainsString('new WebhookProcessor()', $indexCode);
     }
 
     /**


### PR DESCRIPTION
## Summary
- инкапсулирован webhook в класс `WebhookProcessor` с методами `loadConfig`, `handleStart`, `fetchState`, `processMessage`, `sendResponse`
- `index.php` теперь создаёт `WebhookProcessor` и вызывает `handle`
- тест обновлён для проверки использования класса

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a452c35434833383746fa29d3dc778