### PR TITLE
feat: add request dto

### DIFF
--- a/bracelet/Request.php
+++ b/bracelet/Request.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bracelet;
+
+/**
+ * DTO, инкапсулирующий данные входящего запроса Telegram.
+ *
+ * Объект хранит исходное сообщение и ключевые идентификаторы,
+ * необходимые для дальнейшей обработки.
+ */
+class Request
+{
+    /**
+     * Весь массив `message` из обновления Telegram.
+     *
+     * @var array
+     */
+    public array $message;
+
+    /**
+     * Уникальный идентификатор чата, откуда пришёл запрос.
+     */
+    public int $chatId;
+
+    /**
+     * Идентификатор пользователя Telegram.
+     */
+    public int $userId;
+
+    /**
+     * Предпочитаемый язык пользователя (ISO 639-1).
+     */
+    public string $userLang;
+
+    /**
+     * Конструктор заполняет все свойства DTO.
+     *
+     * @param array  $message  Исходное сообщение Telegram.
+     * @param int    $chatId   Идентификатор чата.
+     * @param int    $userId   Идентификатор пользователя.
+     * @param string $userLang Код языка пользователя.
+     */
+    public function __construct(array $message, int $chatId, int $userId, string $userLang)
+    {
+        $this->message  = $message;
+        $this->chatId   = $chatId;
+        $this->userId   = $userId;
+        $this->userLang = $userLang;
+    }
+}

--- a/bracelet/RequestHandler.php
+++ b/bracelet/RequestHandler.php
@@ -54,16 +54,16 @@ class RequestHandler
     }
 
     /**
-     * Считывает и валидирует запрос, возвращая данные сообщения.
+     * Считывает и валидирует запрос, возвращая DTO с данными сообщения.
      *
-     * @return array{message: array, chatId: int, userId: int, userLang: string} Данные сообщения пользователя.
+     * @return Request Объект, содержащий все необходимые данные входящего сообщения.
      *
      * @throws InvalidIpException      Если IP-адрес не принадлежит Telegram.
      * @throws InvalidTokenException   При некорректном секретном токене.
      * @throws OversizedBodyException  Если размер тела превышает допустимый.
      * @throws BadRequestException     При пустом теле, ошибочном JSON или отсутствии поля `message`.
      */
-    public function handle(): array
+    public function handle(): Request
     {
         // Получаем заголовки и приводим их к нижнему регистру для единообразия.
         $headers = function_exists('getallheaders') ? getallheaders() : [];
@@ -147,12 +147,8 @@ class RequestHandler
         $userId = $msg['from']['id'];
         $userLang = $msg['from']['language_code'] ?? 'ru';
 
-        return [
-            'message' => $msg,
-            'chatId' => $chatId,
-            'userId' => $userId,
-            'userLang' => $userLang,
-        ];
+        // Возвращаем DTO с заполненными полями.
+        return new Request($msg, $chatId, $userId, $userLang);
     }
 }
 

--- a/bracelet/webhook.php
+++ b/bracelet/webhook.php
@@ -117,10 +117,11 @@ namespace Bracelet {
 
             // Читаем и валидируем входящий запрос.
             $req            = $this->requestHandler->handle();
-            $this->msg      = $req['message'];
-            $this->chatId   = $req['chatId'];
-            $this->userId   = $req['userId'];
-            $this->userLang = $req['userLang'];
+            // Объект Request предоставляет готовые свойства вместо индексов массива.
+            $this->msg      = $req->message;
+            $this->chatId   = $req->chatId;
+            $this->userId   = $req->userId;
+            $this->userLang = $req->userLang;
 
             // Устанавливаем соединение с базой данных.
             try {

--- a/tests/RequestHandlerExceptionTest.php
+++ b/tests/RequestHandlerExceptionTest.php
@@ -1,96 +1,151 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use Bracelet\RequestHandler;
-
-/**
- * Набор тестов, проверяющих выброс собственных исключений RequestHandler.
- */
-final class RequestHandlerExceptionTest extends TestCase
-{
+namespace Bracelet {
     /**
-     * Заголовки, возвращаемые фиктивной функцией getallheaders().
+     * Заглушка для функции file_get_contents внутри пространства имён Bracelet.
+     * Она позволяет тестам задавать содержимое входного потока `php://input`.
      *
-     * @var array<string,string>
+     * @param string $filename Имя файла, запрос к которому производится.
+     * @return string           Содержимое, предоставленное тестом, либо данные реального файла.
      */
-    public static array $headers = [];
-
-    /**
-     * Переопределяем функцию getallheaders для CLI окружения.
-     * Функция должна существовать до загрузки RequestHandler.
-     *
-     * @return array<string,string> Список тестовых заголовков.
-     */
-    public static function getAllHeadersStub(): array
+    function file_get_contents(string $filename): string
     {
-        return self::$headers;
+        // Для всех файлов, кроме php://input, используем стандартную реализацию.
+        if ($filename !== 'php://input') {
+            return \file_get_contents($filename);
+        }
+        // Возвращаем заранее подготовленное тело запроса.
+        return \RequestHandlerExceptionTest::$body;
     }
+}
 
-    public static function setUpBeforeClass(): void
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use Bracelet\RequestHandler;
+    use Bracelet\Request;
+
+    /**
+     * Набор тестов, проверяющих обработку запросов классом RequestHandler.
+     */
+    final class RequestHandlerExceptionTest extends TestCase
     {
-        // Определяем глобальную функцию getallheaders, если её нет.
-        if (!function_exists('getallheaders')) {
-            function getallheaders() {
-                return RequestHandlerExceptionTest::getAllHeadersStub();
+        /**
+         * Заголовки, возвращаемые фиктивной функцией getallheaders().
+         *
+         * @var array<string,string>
+         */
+        public static array $headers = [];
+
+        /**
+         * Содержимое входящего тела запроса для заглушки `file_get_contents`.
+         */
+        public static string $body = '';
+
+        /**
+         * Переопределяем функцию getallheaders для CLI окружения.
+         * Функция должна существовать до загрузки RequestHandler.
+         *
+         * @return array<string,string> Список тестовых заголовков.
+         */
+        public static function getAllHeadersStub(): array
+        {
+            return self::$headers;
+        }
+
+        public static function setUpBeforeClass(): void
+        {
+            // Определяем глобальную функцию getallheaders, если её нет.
+            if (!function_exists('getallheaders')) {
+                function getallheaders() {
+                    return RequestHandlerExceptionTest::getAllHeadersStub();
+                }
             }
         }
-    }
 
-    protected function setUp(): void
-    {
-        $_SERVER = [];
-        $_ENV['WEBHOOK_SECRET'] = '';
-        self::$headers = [];
-    }
+        protected function setUp(): void
+        {
+            $_SERVER = [];
+            $_ENV['WEBHOOK_SECRET'] = '';
+            self::$headers = [];
+            self::$body = '';
+        }
 
-    /**
-     * При обращении с IP вне диапазона Telegram выбрасывается InvalidIpException.
-     */
-    public function testInvalidIpThrowsException(): void
-    {
-        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
-        $handler = new RequestHandler();
-        $this->expectException(\Bracelet\InvalidIpException::class);
-        $handler->handle();
-    }
+        /**
+         * При обращении с IP вне диапазона Telegram выбрасывается InvalidIpException.
+         */
+        public function testInvalidIpThrowsException(): void
+        {
+            $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+            $handler = new RequestHandler();
+            $this->expectException(\Bracelet\InvalidIpException::class);
+            $handler->handle();
+        }
 
-    /**
-     * Некорректный токен приводит к InvalidTokenException.
-     */
-    public function testInvalidTokenThrowsException(): void
-    {
-        $_SERVER['REMOTE_ADDR'] = '149.154.160.1'; // допустимый IP Telegram
-        $_ENV['WEBHOOK_SECRET'] = 'secret';
-        self::$headers = ['X-Telegram-Bot-Api-Secret-Token' => 'wrong'];
+        /**
+         * Некорректный токен приводит к InvalidTokenException.
+         */
+        public function testInvalidTokenThrowsException(): void
+        {
+            $_SERVER['REMOTE_ADDR'] = '149.154.160.1'; // допустимый IP Telegram
+            $_ENV['WEBHOOK_SECRET'] = 'secret';
+            self::$headers = ['X-Telegram-Bot-Api-Secret-Token' => 'wrong'];
 
-        $handler = new RequestHandler();
-        $this->expectException(\Bracelet\InvalidTokenException::class);
-        $handler->handle();
-    }
+            $handler = new RequestHandler();
+            $this->expectException(\Bracelet\InvalidTokenException::class);
+            $handler->handle();
+        }
 
-    /**
-     * Превышение размера тела по заголовку вызывает OversizedBodyException.
-     */
-    public function testOversizedBodyHeaderThrowsException(): void
-    {
-        $_SERVER['REMOTE_ADDR'] = '149.154.160.1';
-        $_SERVER['CONTENT_LENGTH'] = '2048';
+        /**
+         * Превышение размера тела по заголовку вызывает OversizedBodyException.
+         */
+        public function testOversizedBodyHeaderThrowsException(): void
+        {
+            $_SERVER['REMOTE_ADDR'] = '149.154.160.1';
+            $_SERVER['CONTENT_LENGTH'] = '2048';
 
-        // Устанавливаем очень маленький лимит, чтобы сработала проверка.
-        $handler = new RequestHandler(false, 1024);
-        $this->expectException(\Bracelet\OversizedBodyException::class);
-        $handler->handle();
-    }
+            // Устанавливаем очень маленький лимит, чтобы сработала проверка.
+            $handler = new RequestHandler(false, 1024);
+            $this->expectException(\Bracelet\OversizedBodyException::class);
+            $handler->handle();
+        }
 
-    /**
-     * Пустое тело запроса приводит к BadRequestException.
-     */
-    public function testEmptyBodyThrowsException(): void
-    {
-        $_SERVER['REMOTE_ADDR'] = '149.154.160.1';
-        $handler = new RequestHandler();
-        $this->expectException(\Bracelet\BadRequestException::class);
-        $handler->handle();
+        /**
+         * Пустое тело запроса приводит к BadRequestException.
+         */
+        public function testEmptyBodyThrowsException(): void
+        {
+            $_SERVER['REMOTE_ADDR'] = '149.154.160.1';
+            $handler = new RequestHandler();
+            $this->expectException(\Bracelet\BadRequestException::class);
+            $handler->handle();
+        }
+
+        /**
+         * Успешный разбор запроса заполняет DTO корректными данными.
+         */
+        public function testHandleReturnsFilledRequest(): void
+        {
+            $_SERVER['REMOTE_ADDR'] = '149.154.160.1';
+
+            // Формируем минимальное обновление Telegram.
+            $update = [
+                'message' => [
+                    'chat' => ['id' => 1],
+                    'from' => ['id' => 42, 'language_code' => 'ru'],
+                    'text' => 'привет',
+                ],
+            ];
+            self::$body = json_encode($update, JSON_UNESCAPED_UNICODE);
+
+            $handler = new RequestHandler();
+            $request = $handler->handle();
+
+            $this->assertInstanceOf(Request::class, $request);
+            $this->assertSame($update['message'], $request->message);
+            $this->assertSame(1, $request->chatId);
+            $this->assertSame(42, $request->userId);
+            $this->assertSame('ru', $request->userLang);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `Bracelet\Request` data object for incoming updates
- return Request object from RequestHandler and adapt webhook
- extend tests to assert Request DTO fields

## Testing
- `vendor/bin/phpunit --display-notices`


------
https://chatgpt.com/codex/tasks/task_e_68a455c9de1c8333aca0f0e6ea848e57