### PR TITLE
Обработка ошибок webhook в index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Bracelet\WebhookProcessor;
+use Bracelet\{WebhookProcessor, InvalidIpException, InvalidTokenException, OversizedBodyException, BadRequestException};
+use function Bracelet\logError;
 
 // Путь к автозагрузчику Composer.
 $autoload = __DIR__ . '/vendor/autoload.php';
@@ -19,6 +20,27 @@ $config = require __DIR__ . '/bracelet/config.php';
 
 /**
  * Создаём обработчик и запускаем обработку входящего HTTP-запроса Telegram.
+ *
+ * Оборачиваем основные действия в блоки try...catch, чтобы корректно
+ * реагировать на различные типы ошибок и устанавливать соответствующие
+ * HTTP‑коды ответа. Все сообщения об ошибках фиксируются в логах.
  */
-$processor = new WebhookProcessor($config); // new WebhookProcessor()
-$processor->handle();
+try {
+    // Инициализируем обработчик webhook-запросов.
+    $processor = new WebhookProcessor($config); // new WebhookProcessor()
+    // Запускаем непосредственную обработку входящего HTTP-запроса.
+    $processor->handle();
+} catch (InvalidIpException|InvalidTokenException $e) {
+    // Запрос отклонён: IP не принадлежит Telegram или токен неверен.
+    logError('Запрос отклонён: ' . $e->getMessage());
+    http_response_code(403); // Недостаточно прав для выполнения запроса.
+} catch (OversizedBodyException $e) {
+    // Размер тела запроса превышает допустимый лимит.
+    logError('Слишком большой запрос: ' . $e->getMessage());
+    http_response_code(413); // Слишком большой запрос.
+} catch (BadRequestException $e) {
+    // Ошибка в формате запроса: пустое тело, неверный JSON и т.п.
+    logError('Некорректный запрос: ' . $e->getMessage());
+    http_response_code(400); // Некорректный запрос клиента.
+    echo $e->getMessage();
+}


### PR DESCRIPTION
## Summary
- добавить обработку исключений для WebhookProcessor в `index.php`
- логировать ошибки и возвращать корректные HTTP‑коды (403, 413, 400)

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a46755ca00833382c44de78f0f3e0a